### PR TITLE
[docker] Use official release tag 4.6.0 for Hue version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
         SERVICE_PRECONDITION: "namenode:50070 datanode:50075 hive-metastore-postgresql:5432 resourcemanager:8088 hive-metastore:9083"
   
   hue:
-    image: gethue/hue:20200122-135001
+    image: gethue/hue:4.6.0
     environment:
         SERVICE_PRECONDITION: "namenode:50070 datanode:50075 hive-metastore-postgresql:5432 resourcemanager:8088 hive-metastore:9083 huedb:5000"
     ports:


### PR DESCRIPTION
Safer to use this or 'latest'. 4.6.0 is the latest release.

https://hub.docker.com/layers/gethue/hue/4.6.0/images/sha256-c797c1c8b228947ed50a63623b5418ecc254dc72b0189065a3517ce44dea03ca

Other tags are nightly tags that will be clean-up over time.